### PR TITLE
Make browser failures fatal

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -52,6 +52,7 @@ module.exports = ->
       options:
         output: 'spec/result.xml'
         reporter: 'spec'
+        failWithOutput: true
       all: ['spec/runner.html']
 
     # Coding standards


### PR DESCRIPTION
Now CI build just happily ignores browser failures, causing us not to notice things like #35 
