### PR TITLE
Make it safe to call disconnect on Node.js

### DIFF
--- a/src/helpers/platform.coffee
+++ b/src/helpers/platform.coffee
@@ -36,7 +36,9 @@ if not isBrowser()
     addEventListener: (event, listener, capture, wantsUntrusted) ->
       @on event, listener
     close: () ->
+      return unless @connection
       @connection.close()
+      @connection = null
     send: (msg) ->
       @connection.sendUTF msg
     


### PR DESCRIPTION
Currently it can leave the client in inconsistent state, or throw an error