### PR TITLE
Optional debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var debug = require('debug')('fbp-protocol-client');
 exports.transports = {
   'websocket': require('./lib/websocket'),
   'iframe': require('./lib/iframe'),
@@ -10,7 +11,7 @@ exports.connection = require('./helpers/connection');
 try {
   exports.transports.microflo = require('./lib/microflo');
 } catch (e) {
-  console.log('fbp-protocol-client: MicroFlo transport unavailable: ' + e.message);
+  debug('MicroFlo transport unavailable: ' + e.message);
 }
 
 exports.getTransport = function (transport) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "debug": "^3.1.0",
     "websocket": "~1.0.22"
   },
   "optionalDependencies": {

--- a/src/helpers/platform.coffee
+++ b/src/helpers/platform.coffee
@@ -1,10 +1,10 @@
-
 isBrowser = () ->
   return !(typeof(process) != 'undefined' && process.execPath && process.execPath.indexOf('node') != -1)
 
 EventEmitter = require('events').EventEmitter
 
 if not isBrowser()
+  debug = require('debug') 'fbp-protocol-client:platform'
   # Simple compatibility layer between node.js WebSocket client and native browser APIs
   # Respects events: open, close, message, error
   # Note: no data is passed with open and close events
@@ -17,7 +17,7 @@ if not isBrowser()
       @client.on 'connectFailed', (error) =>
         @emit 'error', error
       @client.on 'connect', (connection) =>
-        console.log 'WARNING: multiple connections for one NodeWebSocketClient' if @connection
+        debug 'WARNING: multiple connections for one NodeWebSocketClient' if @connection
         @connection = connection
         connection.on 'error', (error) =>
           @connection = null

--- a/src/lib/microflo.coffee
+++ b/src/lib/microflo.coffee
@@ -1,5 +1,6 @@
 Base = require './base'
 microflo = require 'microflo'
+debug = require('debug') 'fbp-protocol-client:microflo'
 
 parseQueryString = (queryString) ->
   queries = queryString.split "&"
@@ -102,7 +103,7 @@ class MicroFloRuntime extends Base
       runtime.device.open () =>
         @connecting = false
         if err
-          console.log 'MicroFlo error:', err
+          debug 'MicroFlo error:', err
           @emit 'error', err
           return
         @runtime = runtime
@@ -164,8 +165,8 @@ class MicroFloRuntime extends Base
     try
       @runtime.handleMessage msg
     catch e
-      console.log e.stack
-      console.log e
+      debug e.stack
+      debug e
 
   onMessage: (message) =>
     switch message.data.protocol

--- a/src/lib/webrtc.coffee
+++ b/src/lib/webrtc.coffee
@@ -1,4 +1,5 @@
 Base = require './base'
+debug = require('debug') 'fbp-protocol-client:webrtc'
 
 class WebRTCRuntime extends Base
   constructor: (definition) ->
@@ -7,7 +8,6 @@ class WebRTCRuntime extends Base
     @connection = null
     @protocol = 'webrtc'
     @buffer = []
-    @debug = false
     super definition
 
   getElement: ->
@@ -54,7 +54,7 @@ class WebRTCRuntime extends Base
     @peer.on 'channel:opened:chat', (id, dc) =>
       @connection = dc
       @connection.onmessage = (data) =>
-        console.log 'message', data.data if @debug
+        debug 'message', data.data
         @handleMessage data.data
       @connecting = false
       @sendRuntime 'getruntime', {}
@@ -91,7 +91,7 @@ class WebRTCRuntime extends Base
       return
 
     return unless @connection
-    console.log 'send', m if @debug
+    debug 'send', m
     @connection.send JSON.stringify m
 
   handleError: (error) =>


### PR DESCRIPTION
Right now fbp-protocol-client is a bit annoying with the "MicroFlo not available" messages on Node.js. This utilizes the debug module to make all output opt-in.