### PR TITLE
websocket.isConnected(): Don't return true when connecting

### DIFF
--- a/src/lib/websocket.coffee
+++ b/src/lib/websocket.coffee
@@ -38,7 +38,7 @@ class WebSocketRuntime extends Base
 
     @container
 
-  isConnected: -> @connection isnt null
+  isConnected: -> @connection and @client.connecting == false
 
   connect: ->
     return if @connection or @connecting


### PR DESCRIPTION
Fixes issue in fbp-spec where communication fails
because it cannot be etablished even if isConnected() returned true